### PR TITLE
chore: refresh Claude and Codex patch baselines

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -17,7 +17,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.257",
+      "last_known_version": "v2.1.258",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -63,7 +63,7 @@
         "per_client_skill"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.152.0",
+      "last_known_version": "rust-v0.152.1",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Claude Code and Codex patch baselines**. Advance Claude Code to `v2.1.258`
+  and Codex CLI to `rust-v0.152.1`. Their primary notes contain only a macOS
+  launch repair, remote-session message replay repair, and Guardian Node REPL
+  policy fix; neither patch changes a configuration schema agnix validates.
 - **OpenCode release baseline**. Advance OpenCode to `v1.18.26`; its primary
   release notes contain model-provider, replay, timing, patch metadata, Azure
   sign-in, and desktop bug fixes, with no change to a configuration surface


### PR DESCRIPTION
Closes #1479. Closes #1480.

## Summary
- advance Claude Code to v2.1.258
- advance Codex CLI to rust-v0.152.1
- record that both patch releases are runtime fixes with no validated schema change

## Validation
- `UPDATE_BASELINES=true scripts/check-tool-releases.sh` (`ok=12 new=0 skipped=0`)
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo test -p agnix-cli --test rule_parity`
- `cargo fmt --all -- --check`
- `cmp -s CLAUDE.md AGENTS.md`
- `git diff --check`