### PR TITLE
release: v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-09-06
+
 ### Changed
 - **Claude Code 2.1.261 and ecosystem baseline refresh**. Add `CC-SET-030`
   for local-command entries that Claude Code silently skips in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.52.1"
+version = "0.53.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.52.1" }
-agnix-core = { path = "crates/agnix-core", version = "0.52.1" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.53.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.53.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.52.1
+pluginVersion = 0.53.0
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.52.1"
+version = "0.53.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "Lint agent configurations before they break your workflow. 455 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",

--- a/pypi/agnix/__init__.py
+++ b/pypi/agnix/__init__.py
@@ -13,7 +13,7 @@ import sysconfig
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-__version__ = "0.52.1"
+__version__ = "0.53.0"
 
 __all__ = ["AgnixError", "binary_path", "lint", "run", "version", "__version__"]
 

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnix"
-version = "0.52.1"
+version = "0.53.0"
 description = "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@
 # name is deliberately different so the two can never collide on PyPI.
 [project]
 name = "agnix-pre-commit"
-version = "0.52.1"
+version = "0.53.0"
 description = "pre-commit shim that installs the agnix wheel. Not published to PyPI."
 requires-python = ">=3.9"
-dependencies = ["agnix==0.52.1"]
+dependencies = ["agnix==0.53.0"]
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
Minor release for the new CC-SET-030 rule and accumulated maintenance.

Local gates: cargo check, full workspace tests, all-target/all-feature clippy with warnings denied, fmt, bookkeeping, locale sync, and CLAUDE/AGENTS byte identity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application logic in the diff—only version metadata and changelog text for an already-landed minor release.
> 
> **Overview**
> **Cuts release v0.53.0** by bumping `0.52.1` → `0.53.0` across the Rust workspace (`Cargo.toml` / `Cargo.lock`), editor extensions (VS Code, JetBrains, Zed), npm and PyPI packages, the Claude plugin manifest, and the pre-commit shim dependency pin.
> 
> **Documents 0.53.0 in `CHANGELOG.md`**, including the new **`CC-SET-030`** rule for local-command entries Claude Code skips in `managedMcpServers`, refreshed Claude Code **2.1.261** / Codex **0.153** validation baselines (new TUI and context-management keys), ecosystem spec-hash updates, and routine maintenance (CodeQL, lockfiles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925d5bdb308c89bcb52d95a9dbb5fdeabe57d2a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->